### PR TITLE
feat: WebConfig.java에 CORS 허용 설정

### DIFF
--- a/backend/check-tracker/src/main/java/com/hohohehe/checktracker/config/WebConfig.java
+++ b/backend/check-tracker/src/main/java/com/hohohehe/checktracker/config/WebConfig.java
@@ -1,0 +1,28 @@
+package com.hohohehe.checktracker.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig {
+
+    @Value("${cors.allowed-origins}")
+    private String allowedOrigins;
+
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**")
+                        .allowedOrigins(allowedOrigins)
+                        .allowedMethods("GET", "POST")
+                        .allowedHeaders("Content-Type", "Authorization")
+                        .allowCredentials(true);
+            }
+        };
+    }
+}

--- a/backend/check-tracker/src/main/resources/application-dev.yml
+++ b/backend/check-tracker/src/main/resources/application-dev.yml
@@ -1,0 +1,2 @@
+cors:
+  allowed-origins: "http://localhost:5173"

--- a/backend/check-tracker/src/main/resources/application-local.yml
+++ b/backend/check-tracker/src/main/resources/application-local.yml
@@ -1,0 +1,2 @@
+cors:
+  allowed-origins: "http://localhost:5173"


### PR DESCRIPTION
- 환경 별 허용하는 origin을 다르게 할 수 있도록 application.yml에서 값을 불러와 세팅
- 보안의 이유로 메소드는 GET/POST만 허용하도록 제한
- 보안의 이유로 Headers도 최소한의 지켜야 할 헤더 목록 추가