### PR TITLE
feat: 체크리스트 생성/조회 controller 메소드 생성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+**/build/
+**/.gradle/
+
 # Created by https://www.toptal.com/developers/gitignore/api/intellij,java,gradle,react,node
 # Edit at https://www.toptal.com/developers/gitignore?templates=intellij,java,gradle,react,node
 
@@ -6,30 +9,30 @@
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
 # User-specific stuff
-.idea/**/workspace.xml
-.idea/**/tasks.xml
-.idea/**/usage.statistics.xml
-.idea/**/dictionaries
-.idea/**/shelf
+**/.idea/**/workspace.xml
+**/.idea/**/tasks.xml
+**/.idea/**/usage.statistics.xml
+**/.idea/**/dictionaries
+**/.idea/**/shelf
 
 # AWS User-specific
-.idea/**/aws.xml
+**/.idea/**/aws.xml
 
 # Generated files
-.idea/**/contentModel.xml
+**/.idea/**/contentModel.xml
 
 # Sensitive or high-churn files
-.idea/**/dataSources/
-.idea/**/dataSources.ids
-.idea/**/dataSources.local.xml
-.idea/**/sqlDataSources.xml
-.idea/**/dynamic.xml
-.idea/**/uiDesigner.xml
-.idea/**/dbnavigator.xml
+**/.idea/**/dataSources/
+**/.idea/**/dataSources.ids
+**/.idea/**/dataSources.local.xml
+**/.idea/**/sqlDataSources.xml
+**/.idea/**/dynamic.xml
+**/.idea/**/uiDesigner.xml
+**/.idea/**/dbnavigator.xml
 
 # Gradle
-.idea/**/gradle.xml
-.idea/**/libraries
+**/.idea/**/gradle.xml
+**/.idea/**/libraries
 
 # Gradle and Maven with auto-import
 # When using Gradle or Maven with auto-import, you should exclude module files,
@@ -48,7 +51,7 @@
 cmake-build-*/
 
 # Mongo Explorer plugin
-.idea/**/mongoSettings.xml
+**/.idea/**/mongoSettings.xml
 
 # File-based project format
 *.iws
@@ -63,10 +66,10 @@ out/
 atlassian-ide-plugin.xml
 
 # Cursive Clojure plugin
-.idea/replstate.xml
+**/.idea/replstate.xml
 
 # SonarLint plugin
-.idea/sonarlint/
+**/.idea/sonarlint/
 
 # Crashlytics plugin (for Android Studio and IntelliJ)
 com_crashlytics_export_strings.xml
@@ -75,10 +78,10 @@ crashlytics-build.properties
 fabric.properties
 
 # Editor-based Rest Client
-.idea/httpRequests
+**/.idea/httpRequests
 
 # Android studio 3.1+ serialized cache file
-.idea/caches/build_file_checksums.ser
+**/.idea/caches/build_file_checksums.ser
 
 ### Intellij Patch ###
 # Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
@@ -90,29 +93,29 @@ fabric.properties
 
 # Sonarlint plugin
 # https://plugins.jetbrains.com/plugin/7973-sonarlint
-.idea/**/sonarlint/
+**/.idea/**/sonarlint/
 
 # SonarQube Plugin
 # https://plugins.jetbrains.com/plugin/7238-sonarqube-community-plugin
-.idea/**/sonarIssues.xml
+**/.idea/**/sonarIssues.xml
 
 # Markdown Navigator plugin
 # https://plugins.jetbrains.com/plugin/7896-markdown-navigator-enhanced
-.idea/**/markdown-navigator.xml
-.idea/**/markdown-navigator-enh.xml
-.idea/**/markdown-navigator/
+**/.idea/**/markdown-navigator.xml
+**/.idea/**/markdown-navigator-enh.xml
+**/.idea/**/markdown-navigator/
 
 # Cache file creation bug
 # See https://youtrack.jetbrains.com/issue/JBR-2257
-.idea/$CACHE_FILE$
+**/.idea/$CACHE_FILE$
 
 # CodeStream plugin
 # https://plugins.jetbrains.com/plugin/12206-codestream
-.idea/codestream.xml
+**/.idea/codestream.xml
 
 # Azure Toolkit for IntelliJ plugin
 # https://plugins.jetbrains.com/plugin/8053-azure-toolkit-for-intellij
-.idea/**/azureSettings.xml
+**/.idea/**/azureSettings.xml
 
 ### Java ###
 # Compiled class file

--- a/backend/check-tracker/.idea/dataSources.xml
+++ b/backend/check-tracker/.idea/dataSources.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DataSourceManagerImpl" format="xml" multifile-model="true">
+    <data-source source="LOCAL" name="checkTracker@localhost" uuid="46a0371d-8054-4002-94c8-26fe9a8519ae">
+      <driver-ref>mysql.8</driver-ref>
+      <synchronize>true</synchronize>
+      <jdbc-driver>com.mysql.cj.jdbc.Driver</jdbc-driver>
+      <jdbc-url>jdbc:mysql://localhost:3300/checkTracker</jdbc-url>
+      <jdbc-additional-properties>
+        <property name="com.intellij.clouds.kubernetes.db.host.port" />
+        <property name="com.intellij.clouds.kubernetes.db.enabled" value="false" />
+        <property name="com.intellij.clouds.kubernetes.db.container.port" />
+      </jdbc-additional-properties>
+      <working-dir>$ProjectFileDir$</working-dir>
+    </data-source>
+  </component>
+</project>

--- a/backend/check-tracker/.idea/jpa.xml
+++ b/backend/check-tracker/.idea/jpa.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JpaBuddyIdeaProjectConfig">
+    <option name="defaultUnitInitialized" value="true" />
+    <option name="renamerInitialized" value="true" />
+  </component>
+</project>

--- a/backend/check-tracker/.idea/modules/checkTracker.test.iml
+++ b/backend/check-tracker/.idea/modules/checkTracker.test.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="AdditionalModuleElements">
+    <content url="file://$MODULE_DIR$/../../build/generated/sources/annotationProcessor/java/test">
+      <sourceFolder url="file://$MODULE_DIR$/../../build/generated/sources/annotationProcessor/java/test" isTestSource="true" generated="true" />
+    </content>
+  </component>
+</module>

--- a/backend/check-tracker/build.gradle
+++ b/backend/check-tracker/build.gradle
@@ -32,6 +32,8 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testCompileOnly 'org.projectlombok:lombok'
+	testAnnotationProcessor 'org.projectlombok:lombok'
 }
 
 tasks.named('test') {

--- a/backend/check-tracker/src/main/java/com/hohohehe/checktracker/config/JpaConfig.java
+++ b/backend/check-tracker/src/main/java/com/hohohehe/checktracker/config/JpaConfig.java
@@ -1,0 +1,18 @@
+package com.hohohehe.checktracker.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import java.util.Optional;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaConfig {
+
+    @Bean
+    public AuditorAware<String> auditorAware() {
+        return () -> Optional.of("nsh"); // TODO: 스프링 시큐리티로 인증 기능을 붙이게 될 때, 수정필요
+    }
+}

--- a/backend/check-tracker/src/main/java/com/hohohehe/checktracker/contoller/CheckListController.java
+++ b/backend/check-tracker/src/main/java/com/hohohehe/checktracker/contoller/CheckListController.java
@@ -1,0 +1,37 @@
+package com.hohohehe.checktracker.contoller;
+
+import com.hohohehe.checktracker.domain.CheckList;
+import com.hohohehe.checktracker.dto.request.CheckListRequest;
+import com.hohohehe.checktracker.dto.response.CheckListResponse;
+import com.hohohehe.checktracker.dto.response.Response;
+import com.hohohehe.checktracker.service.CheckListService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/checkLists")
+public class CheckListController {
+
+    private final CheckListService checkListService;
+
+    @GetMapping
+    public ResponseEntity<List<CheckListResponse>> getAllCheckLists() {
+        List<CheckListResponse> results = checkListService.searchCheckList()
+                .stream()
+                .map(CheckListResponse::from)
+                .toList();
+
+        return ResponseEntity.ok(results);
+    }
+
+    @PostMapping
+    public ResponseEntity<Response> addCheckList(@RequestBody CheckListRequest request) {
+        checkListService.saveCheckList(CheckList.of(request));
+
+        return ResponseEntity.ok(Response.of("SC"));
+    }
+}

--- a/backend/check-tracker/src/main/java/com/hohohehe/checktracker/domain/AuditingFields.java
+++ b/backend/check-tracker/src/main/java/com/hohohehe/checktracker/domain/AuditingFields.java
@@ -5,6 +5,10 @@ import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 import lombok.ToString;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
@@ -15,15 +19,19 @@ import java.time.LocalDateTime;
 @MappedSuperclass
 public abstract class AuditingFields {
 
+    @CreatedDate
     @Column(nullable = false)
     private LocalDateTime createdAt;
 
+    @CreatedBy
     @Column(nullable = false)
     private String createdBy;
 
+    @LastModifiedDate
     @Column
     private LocalDateTime modifiedAt;
 
+    @LastModifiedBy
     @Column
     private String modifiedBy;
 }

--- a/backend/check-tracker/src/main/java/com/hohohehe/checktracker/domain/AuditingFields.java
+++ b/backend/check-tracker/src/main/java/com/hohohehe/checktracker/domain/AuditingFields.java
@@ -1,0 +1,29 @@
+package com.hohohehe.checktracker.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@ToString
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public abstract class AuditingFields {
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private String createdBy;
+
+    @Column
+    private LocalDateTime modifiedAt;
+
+    @Column
+    private String modifiedBy;
+}

--- a/backend/check-tracker/src/main/java/com/hohohehe/checktracker/domain/CheckList.java
+++ b/backend/check-tracker/src/main/java/com/hohohehe/checktracker/domain/CheckList.java
@@ -1,0 +1,25 @@
+package com.hohohehe.checktracker.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@ToString(callSuper = true)
+@Table(indexes = {
+        @Index(columnList = "title"),
+        @Index(columnList = "createdAt"),
+        @Index(columnList = "createdBy")
+})
+@Entity
+public class CheckList extends AuditingFields {
+
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    private Long checkListId;
+
+    @Setter
+    @Column(nullable = false)
+    private String title;
+}

--- a/backend/check-tracker/src/main/java/com/hohohehe/checktracker/domain/CheckList.java
+++ b/backend/check-tracker/src/main/java/com/hohohehe/checktracker/domain/CheckList.java
@@ -5,6 +5,8 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
+import java.util.Objects;
+
 @Getter
 @ToString(callSuper = true)
 @Table(indexes = {
@@ -28,5 +30,17 @@ public class CheckList extends AuditingFields {
         checkList.setTitle(title);
 
         return checkList;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof CheckList checkList)) return false;
+        return Objects.equals(checkListId, checkList.checkListId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(checkListId);
     }
 }

--- a/backend/check-tracker/src/main/java/com/hohohehe/checktracker/domain/CheckList.java
+++ b/backend/check-tracker/src/main/java/com/hohohehe/checktracker/domain/CheckList.java
@@ -1,5 +1,6 @@
 package com.hohohehe.checktracker.domain;
 
+import com.hohohehe.checktracker.dto.request.CheckListRequest;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
@@ -28,6 +29,13 @@ public class CheckList extends AuditingFields {
     public static CheckList of(String title) {
         CheckList checkList = new CheckList();
         checkList.setTitle(title);
+
+        return checkList;
+    }
+
+    public static CheckList of(CheckListRequest request) {
+        CheckList checkList = new CheckList();
+        checkList.setTitle(request.title());
 
         return checkList;
     }

--- a/backend/check-tracker/src/main/java/com/hohohehe/checktracker/domain/CheckList.java
+++ b/backend/check-tracker/src/main/java/com/hohohehe/checktracker/domain/CheckList.java
@@ -22,4 +22,11 @@ public class CheckList extends AuditingFields {
     @Setter
     @Column(nullable = false)
     private String title;
+
+    public static CheckList of(String title) {
+        CheckList checkList = new CheckList();
+        checkList.setTitle(title);
+
+        return checkList;
+    }
 }

--- a/backend/check-tracker/src/main/java/com/hohohehe/checktracker/dto/request/CheckListRequest.java
+++ b/backend/check-tracker/src/main/java/com/hohohehe/checktracker/dto/request/CheckListRequest.java
@@ -1,0 +1,6 @@
+package com.hohohehe.checktracker.dto.request;
+
+public record CheckListRequest(
+        String title
+) {
+}

--- a/backend/check-tracker/src/main/java/com/hohohehe/checktracker/dto/response/CheckListResponse.java
+++ b/backend/check-tracker/src/main/java/com/hohohehe/checktracker/dto/response/CheckListResponse.java
@@ -1,0 +1,22 @@
+package com.hohohehe.checktracker.dto.response;
+
+import com.hohohehe.checktracker.domain.CheckList;
+
+import java.time.format.DateTimeFormatter;
+
+public record CheckListResponse(
+        Long checkListId,
+        String title,
+        String createdBy,
+        String createdAt
+) {
+
+    public static CheckListResponse from(final CheckList checkList) {
+        return new CheckListResponse(
+                checkList.getCheckListId(),
+                checkList.getTitle(),
+                checkList.getCreatedBy(),
+                checkList.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+        );
+    }
+}

--- a/backend/check-tracker/src/main/java/com/hohohehe/checktracker/dto/response/Response.java
+++ b/backend/check-tracker/src/main/java/com/hohohehe/checktracker/dto/response/Response.java
@@ -1,0 +1,17 @@
+package com.hohohehe.checktracker.dto.response;
+
+import lombok.*;
+
+public record Response(
+        String result,
+        String message
+) {
+
+    public static Response of(String result, String message) {
+        return new Response(result, message);
+    }
+
+    public static Response of(String result) {
+        return of(result, "");
+    }
+}

--- a/backend/check-tracker/src/main/java/com/hohohehe/checktracker/repository/CheckListRepository.java
+++ b/backend/check-tracker/src/main/java/com/hohohehe/checktracker/repository/CheckListRepository.java
@@ -1,0 +1,11 @@
+package com.hohohehe.checktracker.repository;
+
+import com.hohohehe.checktracker.domain.CheckList;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CheckListRepository extends JpaRepository<CheckList, Long> {
+
+    List<CheckList> findAll();
+}

--- a/backend/check-tracker/src/main/java/com/hohohehe/checktracker/service/CheckListService.java
+++ b/backend/check-tracker/src/main/java/com/hohohehe/checktracker/service/CheckListService.java
@@ -1,0 +1,12 @@
+package com.hohohehe.checktracker.service;
+
+import com.hohohehe.checktracker.domain.CheckList;
+
+import java.util.List;
+
+public interface CheckListService {
+
+    List<CheckList> searchCheckList();
+
+    CheckList saveCheckList(CheckList checkList);
+}

--- a/backend/check-tracker/src/main/java/com/hohohehe/checktracker/service/CheckListServiceImpl.java
+++ b/backend/check-tracker/src/main/java/com/hohohehe/checktracker/service/CheckListServiceImpl.java
@@ -1,0 +1,26 @@
+package com.hohohehe.checktracker.service;
+
+import com.hohohehe.checktracker.domain.CheckList;
+import com.hohohehe.checktracker.repository.CheckListRepository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class CheckListServiceImpl implements CheckListService {
+
+    private final CheckListRepository checkListRepository;
+
+    @Override
+    public List<CheckList> searchCheckList() {
+        return checkListRepository.findAll();
+    }
+
+    @Override
+    public CheckList saveCheckList(CheckList checkList) {
+        return checkListRepository.save(checkList);
+    }
+}

--- a/backend/check-tracker/src/main/resources/application.yml
+++ b/backend/check-tracker/src/main/resources/application.yml
@@ -1,6 +1,12 @@
 server:
   port: 8080
 
+logging:
+  level:
+    com.hohohehe.checktracker: debug
+    org.springframework.web.servlet: debug
+    org.hibernate.type.descriptor.sql.BasicBinder: trace
+
 spring:
   application:
     name: check-tracker
@@ -15,3 +21,4 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        default_batch_fetch_size: 100

--- a/backend/check-tracker/src/main/resources/db/ddl.sql
+++ b/backend/check-tracker/src/main/resources/db/ddl.sql
@@ -13,7 +13,7 @@ CREATE TABLE users(
 
 CREATE TABLE check_list(
     check_list_id BIGINT PRIMARY KEY AUTO_INCREMENT,
-    title VARCHAR(50),
+    title VARCHAR(50) NOT NULL,
     created_at DATETIME NOT NULL,
     created_by VARCHAR(50) NOT NULL,
     modified_at DATETIME,

--- a/backend/check-tracker/src/test/java/com/hohohehe/checktracker/config/MockServiceConfig.java
+++ b/backend/check-tracker/src/test/java/com/hohohehe/checktracker/config/MockServiceConfig.java
@@ -1,0 +1,14 @@
+package com.hohohehe.checktracker.config;
+
+import com.hohohehe.checktracker.service.CheckListService;
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class MockServiceConfig {
+    @Bean
+    public CheckListService checkListService() {
+        return Mockito.mock(CheckListService.class);
+    }
+}

--- a/backend/check-tracker/src/test/java/com/hohohehe/checktracker/contoller/CheckListControllerTest.java
+++ b/backend/check-tracker/src/test/java/com/hohohehe/checktracker/contoller/CheckListControllerTest.java
@@ -1,0 +1,83 @@
+package com.hohohehe.checktracker.contoller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hohohehe.checktracker.config.MockServiceConfig;
+import com.hohohehe.checktracker.domain.CheckList;
+import com.hohohehe.checktracker.dto.request.CheckListRequest;
+import com.hohohehe.checktracker.service.CheckListService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@Import(MockServiceConfig.class)
+@WebMvcTest(CheckListController.class)
+class CheckListControllerTest {
+
+    private final MockMvc mvc;
+    private final ObjectMapper mapper;
+    private final CheckListService checkListService;
+
+    CheckListControllerTest(
+            @Autowired MockMvc mvc,
+            @Autowired ObjectMapper mapper,
+            @Autowired CheckListService checkListService
+    ) {
+        this.mvc = mvc;
+        this.mapper = mapper;
+        this.checkListService = checkListService;
+    }
+
+    @Test
+    void 체크리스트_조회_API_정상작동() throws Exception {
+        // given
+        long checkListId = 1L;
+        given(checkListService.searchCheckList()).willReturn(createCheckList(checkListId));
+
+        // when & then
+        mvc.perform(get("/checkLists"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$[0].checkListId").value(checkListId))
+                .andExpect(jsonPath("$[0].title").value("test"));
+        then(checkListService).should().searchCheckList();
+    }
+
+    @Test
+    void 체크리스트_생성_API_정상작동() throws Exception {
+        // given
+        CheckListRequest request = new CheckListRequest("공부하기");
+        given(checkListService.saveCheckList(any(CheckList.class))).willReturn(any(CheckList.class));
+
+        // when & then
+        mvc.perform(post("/checkLists")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("result").value("SC"));
+        then(checkListService).should().saveCheckList(any(CheckList.class));
+    }
+
+    // fixture
+    private List<CheckList> createCheckList(Long checkListId) {
+        CheckList checkList = CheckList.of("test");
+        ReflectionTestUtils.setField(checkList, "checkListId", checkListId);
+        ReflectionTestUtils.setField(checkList, "createdBy", "nsh");
+        ReflectionTestUtils.setField(checkList, "createdAt", LocalDateTime.now());
+
+        return List.of(checkList);
+    }
+}

--- a/backend/check-tracker/src/test/java/com/hohohehe/checktracker/repository/CheckListRepositoryTest.java
+++ b/backend/check-tracker/src/test/java/com/hohohehe/checktracker/repository/CheckListRepositoryTest.java
@@ -37,6 +37,20 @@ class CheckListRepositoryTest {
                 .isNotNull();
     }
 
+    @Test
+    void givenTestData_whenSave_InsertCheckList() {
+        // given
+        long prevCount = checkListRepository.count();
+        CheckList checkList = CheckList.of("test");
+
+        // when
+        checkListRepository.save(checkList);
+
+        // then
+        assertThat(checkListRepository.count())
+                .isEqualTo(prevCount + 1);
+    }
+
     @EnableJpaAuditing
     @TestConfiguration
     static class TestJpaConfig {

--- a/backend/check-tracker/src/test/java/com/hohohehe/checktracker/repository/CheckListRepositoryTest.java
+++ b/backend/check-tracker/src/test/java/com/hohohehe/checktracker/repository/CheckListRepositoryTest.java
@@ -1,0 +1,48 @@
+package com.hohohehe.checktracker.repository;
+
+import com.hohohehe.checktracker.domain.CheckList;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@Import(CheckListRepositoryTest.TestJpaConfig.class)
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class CheckListRepositoryTest {
+
+    @Autowired
+    private CheckListRepository checkListRepository;
+
+    @Test
+    void givenNoting_whenFindAll_returningChecklists() {
+        // given
+
+        // when
+        List<CheckList> result = checkListRepository.findAll();
+
+        // then
+        assertThat(result)
+                .isNotNull();
+    }
+
+    @EnableJpaAuditing
+    @TestConfiguration
+    static class TestJpaConfig {
+        @Bean
+        AuditorAware<String> auditorAware() {
+            return () -> Optional.of("nsh");
+        }
+    }
+}

--- a/backend/check-tracker/src/test/java/com/hohohehe/checktracker/service/CheckListServiceTest.java
+++ b/backend/check-tracker/src/test/java/com/hohohehe/checktracker/service/CheckListServiceTest.java
@@ -1,0 +1,66 @@
+package com.hohohehe.checktracker.service;
+
+import com.hohohehe.checktracker.domain.CheckList;
+import com.hohohehe.checktracker.repository.CheckListRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+
+@ExtendWith(MockitoExtension.class)
+class CheckListServiceTest {
+
+    @Mock
+    private CheckListRepository checkListRepository;
+
+    @InjectMocks
+    private CheckListServiceImpl checkListService;
+
+    @Test
+    void givenNoting_whenSearchCheckList_returningChecklists() {
+        // given
+        given(checkListRepository.findAll()).willReturn(List.of(new CheckList()));
+
+        // when
+        List<CheckList> result = checkListService.searchCheckList();
+
+        // then
+        assertThat(result)
+                .isNotNull();
+        then(checkListRepository).should().findAll();
+    }
+
+    @Test
+    void givenTestData_whenSaveCheckList_InsertCheckList() {
+        // given
+        CheckList expectedCheckList = createCheckList(1L);
+        given(checkListRepository.save(any(CheckList.class))).willReturn(expectedCheckList);
+        CheckList checkList = CheckList.of("test");
+
+        // when
+        CheckList insertResult = checkListService.saveCheckList(checkList);
+
+        // then
+        assertThat(insertResult)
+                .isEqualTo(expectedCheckList);
+        then(checkListRepository).should().save(checkList);
+    }
+
+    // fixture
+    private CheckList createCheckList(Long checkListId) {
+        CheckList checkList = CheckList.of("test");
+        ReflectionTestUtils.setField(checkList, "checkListId", checkListId);
+
+        return checkList;
+    }
+}


### PR DESCRIPTION
- 체크리스트 생성/조회 controller 메소드 생성
- 체크리스트 생성/조회를 위한 CheckListRequest dto 추가
- 체크리스트 생성 결과를 반환하기 위한 Response dto 추가
- 체크리스트 조회 결과를 반환하기 위한 CheckListResponse dto 추가
- controller로직 검증을 위한 테스트 추가
ㄴ Mockbean이 Spring boot 3.4.0 이후로 Deprecated 되면서 사용할 수 없기 때문에 이를 보완하기 위해 MockServiceConfig 선언 후 직접 Mockbean 생성 후 사용